### PR TITLE
Enable TravisCI building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: rust
+cache: cargo
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true


### PR DESCRIPTION
This will build all commits and pull requests with both the stable, beta and nightly rust compiler. Failure to build with the nightly compiler is ignored.