### PR TITLE
Fix traits

### DIFF
--- a/worker/src/traits.rs
+++ b/worker/src/traits.rs
@@ -36,13 +36,13 @@ pub trait Submitted {
 }
 
 pub trait Downloader<S> {
-    fn fetch_page(task: Task) -> Result<S, Box<dyn Error>>;
+    fn fetch_page(&self, task: Task) -> Result<S, Box<dyn Error>>;
 }
 
 pub trait Extractor<S, D> {
-    fn extract_content(page: S) -> Result<(Vec<Task>, Vec<D>), Box<dyn Error>>;
+    fn extract_content(&self, page: S) -> Result<(Vec<Task>, Vec<D>), Box<dyn Error>>;
 }
 
 pub trait Archive<D> {
-    fn archive_content(content: D) -> Result<(), Box<dyn Error>>;
+    fn archive_content(&self, content: D) -> Result<(), Box<dyn Error>>;
 }


### PR DESCRIPTION
The functions in the traits from #9 are missing `&self` in all function signature. This PR resolves that issue.