### PR TITLE
Downloader client

### DIFF
--- a/worker/src/downloader.rs
+++ b/worker/src/downloader.rs
@@ -7,7 +7,8 @@ use reqwest::Client;
 use crate::task::Task;
 use crate::traits::Downloader;
 
-/// An empty struct to access functions in downloader file
+/// A struct to access functions in downloader file
+/// Contains a reqwest client to send http requests
 pub(crate) struct DefaultDownloader {
     client: reqwest::Client
 }
@@ -19,11 +20,11 @@ impl DefaultDownloader {
 }
 
 impl Downloader<Vec<u8>> for DefaultDownloader {
-    /// Takes a task and returns either a vec<u8> with contents of the url in task, or an error
+    /// Takes a task and returns either a vec<u8> with contents of the url in task, or an error.
     /// If function is successful it will return a Vec<u8> with the page contents, otherwise Error
     fn fetch_page(&self, task: Task) -> Result<Vec<u8>, Box<dyn Error>> {
 
-        // Attempts to get html from url
+        // Attempts to get html from url using the client
         match self.client.get(task.url.as_str()).send() {
             Ok(mut res) => {
                 // Read html as bytes into vec
@@ -58,8 +59,10 @@ mod tests {
 
     #[test]
     fn test_downloader1() {
+        //url points to a local url to the server
         let url = mockito::server_url();
 
+        //string which is to be the body of the server
         let body = "<!DOCTYPE html>
                             <html>
                             <body>
@@ -70,18 +73,22 @@ mod tests {
                             </body>
                             </html>";
 
+        //creates expected value for test, which is the body in Vec<u8>
+        let expected: Vec<u8> = body.as_bytes().to_vec();
+
+        //creates the mock
         let _m = mock("GET", "/")
             .with_status(200)
             .with_header("content-type", "text/plain")
             .with_body(&body)
             .create();
 
+        //attempts to access the mock and downloads the body
         let dl: DefaultDownloader = DefaultDownloader::new();
         let data = dl.fetch_page(
             Task { url: Url::parse(&url).unwrap() });
 
-        let expected: Vec<u8> = body.as_bytes().to_vec();
-
+        //asserts the downloaded data, and expected value is the same
         assert_eq!(data.unwrap(), expected);
     }
 }

--- a/worker/src/downloader.rs
+++ b/worker/src/downloader.rs
@@ -52,10 +52,10 @@ mod tests {
 
     #[test]
     fn test_downloader1() {
-        //url points to a local url to the server
+        // Url points to a local url to the server
         let url = mockito::server_url();
 
-        //string which is to be the body of the server
+        // String which is to be the body of the server
         let body = "<!DOCTYPE html>
                             <html>
                             <body>
@@ -66,22 +66,22 @@ mod tests {
                             </body>
                             </html>";
 
-        //creates expected value for test, which is the body in Vec<u8>
+        // Creates expected value for test, which is the body in Vec<u8>
         let expected: Vec<u8> = body.as_bytes().to_vec();
 
-        //creates the mock
+        // Creates the mock
         let _m = mock("GET", "/")
             .with_status(200)
             .with_header("content-type", "text/plain")
             .with_body(&body)
             .create();
 
-        //attempts to access the mock and downloads the body
+        // Attempts to access the mock and downloads the body
         let dl: DefaultDownloader = DefaultDownloader::new();
         let data = dl.fetch_page(
             &Task { url: Url::parse(&url).unwrap() });
 
-        //asserts the downloaded data, and expected value is the same
+        // Asserts the downloaded data, and expected value is the same
         assert_eq!(data.unwrap(), expected);
     }
 }

--- a/worker/src/downloader.rs
+++ b/worker/src/downloader.rs
@@ -2,20 +2,29 @@ use std::error::Error;
 use std::io::Read;
 
 use reqwest;
+use reqwest::Client;
 
 use crate::task::Task;
 use crate::traits::Downloader;
 
 /// An empty struct to access functions in downloader file
-pub(crate) struct DefaultDownloader;
+pub(crate) struct DefaultDownloader {
+    client: reqwest::Client
+}
 
+impl DefaultDownloader {
+    pub fn new() -> Self {
+        DefaultDownloader { client: Client::new() }
+    }
+}
 
 impl Downloader<Vec<u8>> for DefaultDownloader {
+    /// Takes a task and returns either a vec<u8> with contents of the url in task, or an error
     /// If function is successful it will return a Vec<u8> with the page contents, otherwise Error
     fn fetch_page(&self, task: Task) -> Result<Vec<u8>, Box<dyn Error>> {
 
         // Attempts to get html from url
-        match reqwest::get(task.url.as_str()) {
+        match self.client.get(task.url.as_str()).send() {
             Ok(mut res) => {
                 // Read html as bytes into vec
                 let mut body: Vec<u8> = Vec::new();
@@ -67,7 +76,7 @@ mod tests {
             .with_body(&body)
             .create();
 
-        let dl: DefaultDownloader = DefaultDownloader;
+        let dl: DefaultDownloader = DefaultDownloader::new();
         let data = dl.fetch_page(
             Task { url: Url::parse(&url).unwrap() });
 

--- a/worker/src/downloader.rs
+++ b/worker/src/downloader.rs
@@ -22,7 +22,7 @@ impl DefaultDownloader {
 impl Downloader<Vec<u8>> for DefaultDownloader {
     /// Takes a task and returns either a vec<u8> with contents of the url in task, or an error.
     /// If function is successful it will return a Vec<u8> with the page contents, otherwise Error
-    fn fetch_page(&self, task: Task) -> Result<Vec<u8>, Box<dyn Error>> {
+    fn fetch_page(&self, task: &Task) -> Result<Vec<u8>, Box<dyn Error>> {
         // Attempts to get html from url using the client
         match self.client.get(task.url.as_str()).send() {
             Ok(mut res) => {
@@ -79,7 +79,7 @@ mod tests {
         //attempts to access the mock and downloads the body
         let dl: DefaultDownloader = DefaultDownloader::new();
         let data = dl.fetch_page(
-            Task { url: Url::parse(&url).unwrap() });
+            &Task { url: Url::parse(&url).unwrap() });
 
         //asserts the downloaded data, and expected value is the same
         assert_eq!(data.unwrap(), expected);

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -42,7 +42,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             let found: bool = con.sismember("submitted", &task)?;
             println!("{} is in set: {}", task.url, found);
 
-            let dl: DefaultDownloader = DefaultDownloader;
+            let dl: DefaultDownloader = DefaultDownloader::new();
             let data = dl.fetch_page(task);
             println!("{:?}", String::from_utf8(data.unwrap()))
         }

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     match con_result {
         Ok(mut con) => {
             let task: Task = Task { url: Url::parse("http://erdetfredag.dk/")? };
-            let task2: Task = Task { url: Url::parse("http://wikipedia.dk/")?,  };
+            let task2: Task = Task { url: Url::parse("http://wikipedia.dk/")? };
 
             // Submit tasks to Redis
             let _: () = con.sadd("submitted", &task)?;


### PR DESCRIPTION
Added client field to DefaultDownloader struct. So now one Client is created per Defaultdownloader, instead of a client for each task. 