### PR TITLE
Added normaliser to worker

### DIFF
--- a/worker/src/defaultnormaliser.rs
+++ b/worker/src/defaultnormaliser.rs
@@ -12,9 +12,9 @@ pub struct DefaultNormaliser;
 impl Normaliser for DefaultNormaliser {
     /// Normalising the tasks URL by setting scheme and path to lowercase,
     /// removing the dot in path, removes hash from url and ordering the query.
-    fn normalise(&self, task: Task) -> Result<Task, Box<dyn Error>> {
-        match self.full_normalisation(task.url) {
-            Ok(url) => Ok(Task { url }),
+    fn normalise(&self, url: Url) -> Result<Url, Box<dyn Error>> {
+        match self.full_normalisation(url) {
+            Ok(url) => Ok(url),
             Err(_) => Err(Box::new(NormaliseError("Normalisation went wrong.".into()))),
         }
     }

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -16,6 +16,7 @@ use crate::task::Task;
 use crate::traits::Downloader;
 use crate::void::Void;
 use crate::worker::Worker;
+use crate::defaultnormaliser::DefaultNormaliser;
 
 mod downloader;
 mod extractor;
@@ -43,8 +44,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         .expect("Failed to construct RMQRedisManager");
     let downloader = DefaultDownloader::new();
     let extractor = HTMLExtractorBase::new(HTMLLinkExtractor::new());
+    let normaliser = DefaultNormaliser;
     let archive = Void;
-    let worker = Worker::new("W1".to_string(), manager, downloader, extractor, archive);
+    let worker = Worker::new("W1".to_string(), manager, downloader, extractor, normaliser, archive);
     worker.start();
 
     Ok(())

--- a/worker/src/traits.rs
+++ b/worker/src/traits.rs
@@ -44,7 +44,7 @@ pub trait Downloader<S> {
 }
 
 pub trait Extractor<S, D> {
-    fn extract_content(&self, page: S, url: &Url) -> ExtractResult<(Vec<Task>, Vec<D>)>;
+    fn extract_content(&self, page: S, url: &Url) -> ExtractResult<(Vec<Url>, Vec<D>)>;
 }
 
 pub trait Archive<D> {
@@ -52,5 +52,5 @@ pub trait Archive<D> {
 }
 
 pub trait Normaliser {
-    fn normalise(&self, task: Task) -> Result<Task, Box<dyn Error>>;
+    fn normalise(&self, url: Url) -> Result<Url, Box<dyn Error>>;
 }

--- a/worker/src/worker.rs
+++ b/worker/src/worker.rs
@@ -1,20 +1,25 @@
 use std::marker::PhantomData;
 
-use crate::traits::{Archive, Downloader, Extractor, Manager, TaskProcessResult};
+use crate::traits::{Archive, Downloader, Extractor, Manager, TaskProcessResult, Normaliser};
+use crate::task::Task;
+use std::collections::HashSet;
+use url::Url;
 
 /// A worker is the web crawler module that resolves tasks. The components of the worker
 /// define every aspect of the workers behaviour.
-pub struct Worker<M, L, E, A, S, D>
+pub struct Worker<M, L, E, N, A, S, D>
 where
     M: Manager,
     L: Downloader<S>,
     E: Extractor<S, D>,
+    N: Normaliser,
     A: Archive<D>,
 {
     name: String,
     manager: M,
     downloader: L,
     extractor: E,
+    normaliser: N,
     archive: A,
     // Phantom data markers are used to please the type checker about S and D.
     // Without it will believe that S and D are unused even though the determine the
@@ -23,20 +28,22 @@ where
     _data_type_marker: PhantomData<D>,
 }
 
-impl<M, L, E, A, S, D> Worker<M, L, E, A, S, D>
+impl<M, L, E, N, A, S, D> Worker<M, L, E, N, A, S, D>
 where
     M: Manager,
     L: Downloader<S>,
     E: Extractor<S, D>,
+    N: Normaliser,
     A: Archive<D>,
 {
     /// Create a new worker with the given components.
-    pub fn new(name: String, manager: M, downloader: L, extractor: E, archive: A) -> Self {
+    pub fn new(name: String, manager: M, downloader: L, extractor: E, normaliser: N, archive: A) -> Self {
         Worker {
             name,
             manager,
             downloader,
             extractor,
+            normaliser,
             archive,
             _page_type_marker: PhantomData,
             _data_type_marker: PhantomData,
@@ -62,7 +69,7 @@ where
                             eprintln!("{} failed to extract data from page.", self.name);
                             TaskProcessResult::Err
                         }
-                        Ok((tasks, data)) => {
+                        Ok((mut urls, data)) => {
                             // Archiving
                             for datum in data {
                                 if let Err(e) = self.archive.archive_content(datum) {
@@ -71,7 +78,17 @@ where
                                 }
                             }
 
-                            // Check if extracted links are new, if they are, submit them
+                            // Normalise extracted links
+                            // After normalisation, squash urls into a hash set to remove duplicates
+                            // Erroneous urls are discarded
+                            let tasks: Vec<Task> = urls.drain(..)
+                                .filter_map(|url| self.normaliser.normalise(url).ok())
+                                .collect::<HashSet<Url>>()
+                                .drain()
+                                .map(|url| Task { url })
+                                .collect();
+
+                            // Check if extracted tasks are new, if they are, submit them
                             for task in &tasks {
                                 if let Ok(exists) = self.manager.contains(task) {
                                     if !exists {

--- a/worker/src/worker.rs
+++ b/worker/src/worker.rs
@@ -82,7 +82,16 @@ where
                             // After normalisation, squash urls into a hash set to remove duplicates
                             // Erroneous urls are discarded
                             let tasks: Vec<Task> = urls.drain(..)
-                                .filter_map(|url| self.normaliser.normalise(url).ok())
+                                .filter_map(|url| {
+                                    let url_as_str = String::from(url.as_str());
+                                    match self.normaliser.normalise(url) {
+                                        Ok(normalised_url) => Some(normalised_url),
+                                        Err(_) => {
+                                            eprintln!("{} failed to normalise {}", self.name, url_as_str);
+                                            None
+                                        },
+                                    }
+                                })
                                 .collect::<HashSet<Url>>()
                                 .drain()
                                 .map(|url| Task { url })


### PR DESCRIPTION
The worker will now normalise all links found during extraction and eliminate duplicates. The extractor was changed to return URLs instead of tasks.

Resolves #48