### PR TITLE
Added error classes for normaliser

### DIFF
--- a/worker/src/defaultnormaliser.rs
+++ b/worker/src/defaultnormaliser.rs
@@ -6,81 +6,51 @@ use std::fmt;
 use url::Url;
 use url_normalizer;
 use rand::seq::index::sample;
+use crate::errors::{NormaliseResult, NormaliseError, NormaliseErrorKind};
 
 pub struct DefaultNormaliser;
 
 impl Normaliser for DefaultNormaliser {
     /// Normalising the tasks URL by setting scheme and path to lowercase,
     /// removing the dot in path, removes hash from url and ordering the query.
-    fn normalise(&self, url: Url) -> Result<Url, Box<dyn Error>> {
-        match self.full_normalisation(url) {
-            Ok(url) => Ok(url),
-            Err(_) => Err(Box::new(NormaliseError("Normalisation went wrong.".into()))),
-        }
+    fn normalise(&self, url: Url) -> NormaliseResult<Url> {
+        DefaultNormaliser::full_normalisation(url)
     }
 }
 
 impl DefaultNormaliser {
-    /// Takes a slice of functions which gets applied to the given tasks url.
-    fn custom_normalisation<F>(&self, task: Task, f: F) -> Result<Task, ()> where F: FnOnce(Url) -> Result<Url, ()> {
-        let mut new_url = task.url;
-
-        new_url = f(new_url)?;
-
-        Ok(Task {
-            url: new_url
-        })
-    }
-
     /// Run through all implemented normalisation functions and applying those on the given url.
-    fn full_normalisation(&self, url: Url) -> Result<Url, ()> {
+    fn full_normalisation(url: Url) -> NormaliseResult<Url> {
         let mut new_url = url;
 
         //Normalising by ordering the query in alphabetic order,
         //removes hash from url and changes encrypted to unencrypted.
-        new_url = url_normalizer::normalize(new_url)?;
-        /*
-        new_url = self.removing_dots_in_path(new_url)?; //When creating an url it removes dots by default
-        */
-        new_url = self.scheme_and_host_to_lowercase(new_url)?;
-        new_url = self.converting_encoded_triplets_to_upper(new_url)?;
-        new_url = self.empty_path_to_slash(new_url)?;
+        new_url = url_normalizer::normalize(new_url).map_err(|_| {
+            NormaliseError::new(NormaliseErrorKind::ParsingError, String::from("Failed to normalise using url library"), None)
+        })?;
+
+        new_url = DefaultNormaliser::scheme_and_host_to_lowercase(new_url)?;
+        new_url = DefaultNormaliser::converting_encoded_triplets_to_upper(new_url)?;
+        new_url = DefaultNormaliser::empty_path_to_slash(new_url)?;
 
         Ok(new_url)
     }
 
     ///Sets the scheme and host to lowercase
-    fn scheme_and_host_to_lowercase(&self, url: Url) -> Result<Url, ()> {
+    fn scheme_and_host_to_lowercase(url: Url) -> NormaliseResult<Url> {
         let mut new_url = url;
-
-        let scheme = new_url.scheme().to_lowercase();
 
         if let Some(host) = new_url.host_str() {
             let host = host.to_lowercase();
-
-            match new_url.set_host(Option::Some(host.as_str())) {
-                Ok(_) => {}
-                Err(e) => {
-                    println!("Couldn't set the host: {}", e);
-                }
-            }
+            new_url.set_host(Some(host.as_str())).map_err(|e| {
+                NormaliseError::new(NormaliseErrorKind::ParsingError, String::from("Failed to make host lower-case"), Some(Box::new(e)))
+            })?;
         }
 
-        new_url.set_scheme(scheme.as_str())?;
-
-        Ok(new_url)
-    }
-
-
-    ///Removing the "../" and "./" notations from the path
-    #[allow(dead_code)]
-    fn removing_dots_in_path(&self, url: Url) -> Result<Url, ()> {
-        let mut new_url = url;
-
-        let mut path = new_url.path().to_string();
-        path = path.replace("../", "").replace("./", "");
-
-        new_url.set_path(path.as_str());
+        let scheme = new_url.scheme().to_lowercase();
+        new_url.set_scheme(scheme.as_str()).map_err(|_| {
+            NormaliseError::new(NormaliseErrorKind::ParsingError, String::from("Failed to make scheme lower-case"), None)
+        })?;
 
         Ok(new_url)
     }
@@ -88,7 +58,7 @@ impl DefaultNormaliser {
     /// Converting encoded triplets to uppercase, example:
     /// From: "http://example.com/foo%2a"
     /// To: "http://example.com/foo%2A"
-    fn converting_encoded_triplets_to_upper(&self, url: Url) -> Result<Url, ()> {
+    fn converting_encoded_triplets_to_upper(url: Url) -> NormaliseResult<Url> {
         let new_url = url;
         let mut str_build = "".to_string();
         let some_chars = new_url.as_str().chars();
@@ -112,19 +82,16 @@ impl DefaultNormaliser {
             }
         }
 
-        // Parse the builded string as an url for return
-        match Url::parse(str_build.as_str()) {
-            Ok(url) => Ok(url),
-            Err(e) => {
-                Err(()) //TODO handling Error
-            }
-        }
+        // Parse the built string as an url for return
+        Url::parse(str_build.as_str()).map_err(|e| {
+            NormaliseError::new(NormaliseErrorKind::ParsingError, String::from("Failed converting triplets to uppercase"), Some(Box::new(e)))
+        })
     }
 
     /// Converting an empty path to a slash. Example:
     /// From: "http://example.com"
     /// To: "http://example.com/"
-    fn empty_path_to_slash(&self, url: Url) -> Result<Url, ()> {
+    fn empty_path_to_slash(url: Url) -> NormaliseResult<Url> {
         let new_url = url;
         let url_as_str = new_url.as_str();
 
@@ -132,81 +99,44 @@ impl DefaultNormaliser {
             Ok(new_url)
         } else {
             url_as_str.to_string().push_str("/");
-
-            match Url::parse(url_as_str) {
-                Ok(url) => Ok(url),
-                Err(e) => {
-                    Err(()) //TODO Handling of Error
-                }
-            }
+            Url::parse(url_as_str).map_err(|e| {
+                NormaliseError::new(NormaliseErrorKind::ParsingError, String::from("Failed adding '/' for empty path"), Some(Box::new(e)))
+            })
         }
     }
 }
 
-
-#[derive(Debug)]
-struct NormaliseError(String);
-
-impl fmt::Display for NormaliseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "There is an error: {}", self.0)
-    }
-}
-
-impl Error for NormaliseError {}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_custom_normalisation0() {
-        let normaliser = DefaultNormaliser;
-        let expected_url = "shoot:shoot:shoot";
-        let mut test_task = Task {
-            url: Url::parse("HTTPS://user:pass@sub.HOST.cOm").unwrap()
-        };
-
-
-        let shoot = |url: Url| { Ok(Url::parse("shoot:shoot:shoot").unwrap()) };
-
-        test_task = normaliser.custom_normalisation(test_task, shoot).unwrap();
-
-        assert_eq!(test_task.url.to_string(), expected_url);
-    }
-
-    #[test]
     fn test_empty_path_to_slash() {
-        let normaliser = DefaultNormaliser;
-
         let expected_url = "http://example.com/";
         let mut test_task = Task {
             url: Url::parse("http://example.com").unwrap()
         };
 
-        let test_url = normaliser.empty_path_to_slash(test_task.url).unwrap();
+        let test_url = DefaultNormaliser::empty_path_to_slash(test_task.url).unwrap();
 
         assert_eq!(test_url.to_string(), expected_url);
     }
 
     #[test]
     fn test_converting_encoded_triplets_to_upper() {
-        let normaliser = DefaultNormaliser;
-
         let expected_url = "http://example.com/foo%2A";
         let mut test_task = Task {
             url: Url::parse("http://example.com/foo%2a").unwrap()
         };
 
-        let test_url = normaliser.converting_encoded_triplets_to_upper(test_task.url).unwrap();
+        let test_url = DefaultNormaliser::converting_encoded_triplets_to_upper(test_task.url).unwrap();
 
         assert_eq!(test_url.to_string(), expected_url);
     }
 
     #[test]
     fn test_scheme_and_host_to_lowercase0() {
-        let normaliser = DefaultNormaliser;
-
         let expected_url = "https://user:pass@sub.host.com:8080/p/a/t/h?query=string#hash";
 
         let test_task = Task {
@@ -214,24 +144,19 @@ mod tests {
                 .unwrap(),
         };
 
-        let test_url = normaliser
-            .scheme_and_host_to_lowercase(test_task.url)
-            .unwrap();
+        let test_url = DefaultNormaliser::scheme_and_host_to_lowercase(test_task.url).unwrap();
 
         assert_eq!(test_url.to_string(), expected_url);
     }
 
     #[test]
     fn test_scheme_and_host_to_lowercase1() {
-        let normaliser = DefaultNormaliser;
         let test_task = Task {
             url: Url::parse("HTTPS://user:pass@sub.HOST.cOm:8080/p/a/t/h?query=string#hash")
                 .unwrap(),
         };
 
-        let test_url = normaliser
-            .scheme_and_host_to_lowercase(test_task.url)
-            .unwrap();
+        let test_url = DefaultNormaliser::scheme_and_host_to_lowercase(test_task.url).unwrap();
 
         let test_scheme = test_url.scheme();
         let test_host = test_url.host_str().unwrap();
@@ -244,15 +169,12 @@ mod tests {
 
     #[test]
     fn test_scheme_and_host_to_lowercase2() {
-        let normaliser = DefaultNormaliser;
         let test_task = Task {
             url: Url::parse("HTTPS://user:pass@sub.HOST.cOm:8080/p/a/t/h?query=string#hash")
                 .unwrap(),
         };
 
-        let test_url = normaliser
-            .scheme_and_host_to_lowercase(test_task.url)
-            .unwrap();
+        let test_url = DefaultNormaliser::scheme_and_host_to_lowercase(test_task.url).unwrap();
 
         let test_scheme = test_url.scheme();
         let test_host = test_url.host_str().unwrap();
@@ -265,15 +187,12 @@ mod tests {
 
     #[test]
     fn test_scheme_and_host_to_lowercase3() {
-        let normaliser = DefaultNormaliser;
         let test_task = Task {
             url: Url::parse("urn:oasis:names:specification:docbook:dtd:xml:4.1.2")
                 .unwrap(),
         };
 
-        let test_url = normaliser
-            .scheme_and_host_to_lowercase(test_task.url)
-            .unwrap();
+        let test_url = DefaultNormaliser::scheme_and_host_to_lowercase(test_task.url).unwrap();
 
         assert_eq!(test_url.has_host(), false)
     }

--- a/worker/src/errors.rs
+++ b/worker/src/errors.rs
@@ -23,6 +23,11 @@ pub enum ExtractErrorKind {
 }
 
 #[derive(Debug)]
+pub enum NormaliseErrorKind {
+    ParsingError,        // Could not parse url
+}
+
+#[derive(Debug)]
 pub enum ArchiveErrorKind {
     NetworkError,        // No internet
     UnreachableError,    // No responds
@@ -45,12 +50,14 @@ where
 pub type ManagerError = ScraperError<ManagerErrorKind>;
 pub type DownloadError = ScraperError<DownloadErrorKind>;
 pub type ExtractError = ScraperError<ExtractErrorKind>;
+pub type NormaliseError = ScraperError<NormaliseErrorKind>;
 pub type ArchiveError = ScraperError<ArchiveErrorKind>;
 
 // std Results with web scraper errors
 pub type ManagerResult<T> = std::result::Result<T, ManagerError>;
 pub type DownloadResult<T> = std::result::Result<T, DownloadError>;
 pub type ExtractResult<T> = std::result::Result<T, ExtractError>;
+pub type NormaliseResult<T> = std::result::Result<T, NormaliseError>;
 pub type ArchiveResult<T> = std::result::Result<T, ArchiveError>;
 
 
@@ -92,6 +99,17 @@ impl ExtractError {
     /// Create a new ExtractError with a kind, message, and optional source error.
     pub fn new(kind: ExtractErrorKind, msg: String, source: Option<Box<dyn Error>>) -> Self {
         ExtractError {
+            kind,
+            msg,
+            source,
+        }
+    }
+}
+
+impl NormaliseError {
+    /// Create a new NormaliseError with a kind, message, and optional source error.
+    pub fn new(kind: NormaliseErrorKind, msg: String, source: Option<Box<dyn Error>>) -> Self {
+        NormaliseError {
             kind,
             msg,
             source,
@@ -149,6 +167,12 @@ impl Display for ExtractErrorKind {
     }
 }
 
+impl Display for NormaliseErrorKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 impl Display for ArchiveErrorKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
@@ -160,7 +184,7 @@ impl Display for ArchiveErrorKind {
 mod tests {
     use std::fmt::Display;
 
-    use crate::errors::{ArchiveError, ArchiveErrorKind, DownloadError, DownloadErrorKind, ExtractError, ExtractErrorKind, ManagerError, ManagerErrorKind};
+    use crate::errors::{ArchiveError, ArchiveErrorKind, DownloadError, DownloadErrorKind, ExtractError, ExtractErrorKind, ManagerError, ManagerErrorKind, NormaliseError, NormaliseErrorKind};
 
     /// Testing formatting of ManagerError without source error
     #[test]
@@ -204,13 +228,13 @@ mod tests {
         let error = ArchiveError::new(
             ArchiveErrorKind::ServerError,
             String::from("Server tried to download something and failed"),
-            Some(Box::new(DownloadError::new(
-                DownloadErrorKind::NetworkError,
+            Some(Box::new(NormaliseError::new(
+                NormaliseErrorKind::ParsingError,
                 String::from("Trying to test nested errors"),
                 None,
             ))),
         );
-        let expected_str = "ServerError: Server tried to download something and failed (source: NetworkError: Trying to test nested errors)";
+        let expected_str = "ServerError: Server tried to download something and failed (source: ParsingError: Trying to test nested errors)";
         assert_eq!(format!("{}", error), expected_str);
     }
 }

--- a/worker/src/traits.rs
+++ b/worker/src/traits.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 
 use url::Url;
 
-use crate::errors::{ArchiveResult, DownloadResult, ExtractResult, ManagerResult};
+use crate::errors::{ArchiveResult, DownloadResult, ExtractResult, ManagerResult, NormaliseResult};
 use crate::task::Task;
 
 pub trait Manager {
@@ -52,5 +52,5 @@ pub trait Archive<D> {
 }
 
 pub trait Normaliser {
-    fn normalise(&self, url: Url) -> Result<Url, Box<dyn Error>>;
+    fn normalise(&self, url: Url) -> NormaliseResult<Url>;
 }

--- a/worker/src/worker.rs
+++ b/worker/src/worker.rs
@@ -86,8 +86,8 @@ where
                                     let url_as_str = String::from(url.as_str());
                                     match self.normaliser.normalise(url) {
                                         Ok(normalised_url) => Some(normalised_url),
-                                        Err(_) => {
-                                            eprintln!("{} failed to normalise {}", self.name, url_as_str);
+                                        Err(e) => {
+                                            eprintln!("{} failed to normalise {}, {}", self.name, url_as_str, e);
                                             None
                                         },
                                     }


### PR DESCRIPTION
Normaliser now has error classes similar to the other components. There is currently only one kind; ParisingError.

This PR depends on #59 

Resolves #49 