### PR TITLE
Boxed the Worker's traits allowing different components

### DIFF
--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -172,7 +172,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         let extractor = HTMLExtractorBase::new(HTMLLinkExtractor::new());
         let normaliser = DefaultNormaliser;
         let archive = Void;
-        let worker = Worker::new("W1".to_string(), manager, downloader, extractor, normaliser, archive);
+        let worker = Worker::new(
+            "W1",
+            Box::new(manager),
+            Box::new(downloader),
+            Box::new(extractor),
+            Box::new(normaliser),
+            Box::new(archive),
+        );
         worker.start();
 
         Ok(())

--- a/worker/src/rmqredis.rs
+++ b/worker/src/rmqredis.rs
@@ -122,10 +122,7 @@ impl Manager for RMQRedisManager {
         result.map_err(|e| ManagerError::new(ManagerErrorKind::UnreachableError, String::from("Could not reach manager."), Some(Box::new(e))))
     }
 
-    fn start_listening<F>(&self, f: F)
-        where
-            F: Fn(Task) -> TaskProcessResult,
-    {
+    fn start_listening(&self, resolve_func: &dyn Fn(Task) -> TaskProcessResult) {
         self.channel
             .basic_consume(
                 &self.queue,
@@ -136,7 +133,7 @@ impl Manager for RMQRedisManager {
             .and_then(move |consumer| {
                 consumer.for_each(move |delivery| {
                     let task = Task::deserialise(delivery.data);
-                    let result = f(task);
+                    let result = resolve_func(task);
                     match result {
                         TaskProcessResult::Ok => {
                             self.channel.basic_ack(delivery.delivery_tag, false)

--- a/worker/src/split.rs
+++ b/worker/src/split.rs
@@ -23,11 +23,8 @@ impl<F: Frontier, S: Collection> Manager for SplitManager<F, S> {
         self.collection.submit_task(task)
     }
 
-    fn start_listening<G>(&self, f: G)
-    where
-        G: Fn(Task) -> TaskProcessResult,
-    {
-        self.frontier.start_listening(f)
+    fn start_listening(&self, resolve_func: &dyn Fn(Task) -> TaskProcessResult) {
+        self.frontier.start_listening(resolve_func)
     }
 
     fn close(self) -> ManagerResult<()> {

--- a/worker/src/traits.rs
+++ b/worker/src/traits.rs
@@ -8,9 +8,7 @@ use crate::task::Task;
 pub trait Manager {
     fn submit_task(&self, task: &Task) -> ManagerResult<()>;
 
-    fn start_listening<F>(&self, f: F)
-        where
-        F: Fn(Task) -> TaskProcessResult;
+    fn start_listening(&self, resolve_func: &dyn Fn(Task) -> TaskProcessResult);
 
     fn close(self) -> ManagerResult<()>;
 
@@ -20,9 +18,7 @@ pub trait Manager {
 pub trait Frontier {
     fn submit_task(&self, task: &Task) -> ManagerResult<()>;
 
-    fn start_listening<F>(&self, f: F)
-        where
-        F: Fn(Task) -> TaskProcessResult;
+    fn start_listening(&self, resolve_func: &dyn Fn(Task) -> TaskProcessResult);
 
     fn close(self) -> ManagerResult<()>;
 }


### PR DESCRIPTION
By putting the traits in a box the worker's size is always the same, since the components' size is always the same.

This allow @MathiasMehl to finish the filter because the worker can be instantiated with either Whitelist, Blacklist, and NoFilter without problems.