### PR TITLE
Binding the exchange and collection queue together

### DIFF
--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -196,7 +196,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         args.value_of("rabbitmq-collection-queue").unwrap(),
                         QueueDeclareOptions::default(),
                         FieldTable::default(),
-                    ).wait().map_err(|e| (e))?;
+                    ).wait()?;
 
                 let consumer = channel
                     .basic_consume(
@@ -220,7 +220,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     } else {
                         channel.basic_reject(
                             msg.delivery_tag,
-                            BasicRejectOptions { requeue : true }
+                            BasicRejectOptions { requeue: true },
                         )
                     }
                 }).wait().unwrap();

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -12,8 +12,8 @@ use std::io::ErrorKind;
 use clap::{App, Arg};
 use futures::future::Future;
 use futures::stream::Stream;
-use lapin_futures::{Client, ConnectionProperties};
-use lapin_futures::options::{BasicConsumeOptions, BasicRejectOptions, QueueDeclareOptions};
+use lapin_futures::{Client, ConnectionProperties, ExchangeKind};
+use lapin_futures::options::{BasicConsumeOptions, BasicRejectOptions, QueueDeclareOptions, ExchangeDeclareOptions, QueueBindOptions};
 use lapin_futures::types::FieldTable;
 use log4rs::append::console::ConsoleAppender;
 use log4rs::append::file::FileAppender;
@@ -75,15 +75,23 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .default_value("6379")
                 .value_name("PORT")
                 .help("Specify the redis-port to connect to"),
-        )
-        .arg(
-            Arg::with_name("redis-set")
-                .short("s")
-                .long("redis-set")
-                .env("SCRAPER_REDIS_SET")
-                .default_value("collection")
-                .value_name("SET")
-                .help("Specify the redis set to connect to"),
+        ).arg(
+        Arg::with_name("redis-set")
+            .short("s")
+            .long("redis-set")
+            .env("SCRAPER_REDIS_SET")
+            .default_value("collection")
+            .value_name("SET")
+            .help("Specify the redis set to connect to"),
+    ).
+        arg(
+            Arg::with_name("rabbitmq-routing-key")
+                .short("k")
+                .long("rmq-routing-key")
+                .env("SCRAPER_RABBITMQ_ROUTING_KEY")
+                .default_value("") // No routing-key by default
+                .value_name("KEY")
+                .help("Specify the RabbitMQ routing-key to connect to")
         )
         .arg(
             Arg::with_name("rabbitmq-collection-queue")
@@ -145,7 +153,6 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .help("Specify the log level {error, warn, info, debug, trace, off}")
         ).get_matches();
 
-
     // Load config for logging to stdout and logfile.
     if let Ok(_handle) = log4rs::init_config(
         get_log4rs_config(
@@ -181,49 +188,42 @@ fn main() -> Result<(), Box<dyn Error>> {
                     args.value_of("rmq-address").unwrap(),
                     args.value_of("rmq-port").unwrap(),
                 );
-                futures::executor::spawn(
-                    Client::connect(&rmq_addr, ConnectionProperties::default()).and_then(|client| {
-                        // Finds collection and sees the tasks
-                        client.create_channel().and_then(|channel| {
-                            channel
-                                .queue_declare(
-                                    args.value_of("rabbitmq-collection-queue").unwrap(),
-                                    QueueDeclareOptions::default(),
-                                    FieldTable::default(),
-                                )
-                                .and_then(move |queue| {
-                                    channel
-                                        .basic_consume(
-                                            &queue,
-                                            args.value_of("rabbitmq-consumer-tag").unwrap(),
-                                            BasicConsumeOptions::default(),
-                                            FieldTable::default(),
-                                        )
-                                        .and_then(|consumer| {
-                                            // Copies every task from collection to redis
-                                            consumer.for_each(move |msg| {
-                                                let received_task =
-                                                    Task::deserialise(msg.data).unwrap();
-                                                let add_res: RedisResult<u32> = connection.sadd(
-                                                    args.value_of("redis-set").unwrap(),
-                                                    &received_task,
-                                                );
-                                                if let Ok(_s) = add_res {
-                                                    channel.basic_ack(msg.delivery_tag, false)
-                                                } else {
-                                                    channel.basic_reject(
-                                                        msg.delivery_tag,
-                                                        BasicRejectOptions::default(), //TODO
-                                                    )
-                                                }
-                                            })
-                                        })
-                                })
-                        })
-                    }),
-                )
-                    .wait_future()
-                    .expect("Could not connect to rabbitMQ");
+                let client = Client::connect(&rmq_addr, ConnectionProperties::default()).wait().map_err(|e| (e))?;
+                // Finds collection and sees the tasks
+                let channel = client.create_channel().wait().map_err(|e| (e))?;
+                let queue = channel
+                    .queue_declare(
+                        args.value_of("rabbitmq-collection-queue").unwrap(),
+                        QueueDeclareOptions::default(),
+                        FieldTable::default(),
+                    ).wait().map_err(|e| (e))?;
+
+                let consumer = channel
+                    .basic_consume(
+                        &queue,
+                        args.value_of("rabbitmq-consumer-tag").unwrap(),
+                        BasicConsumeOptions::default(),
+                        FieldTable::default(),
+                    ).wait().map_err(|e| (e))?;
+
+
+                // Copies every task from collection to redis
+                consumer.for_each(move |msg| {
+                    let received_task =
+                        Task::deserialise(msg.data).unwrap();
+                    let add_res: RedisResult<u32> = connection.sadd(
+                        args.value_of("redis-set").unwrap(),
+                        &received_task,
+                    );
+                    if let Ok(_s) = add_res {
+                        channel.basic_ack(msg.delivery_tag, false)
+                    } else {
+                        channel.basic_reject(
+                            msg.delivery_tag,
+                            BasicRejectOptions::default(), //TODO
+                        )
+                    }
+                }).wait().unwrap();
             }
             Err(_) => error!("Could not connect to redis"),
         }

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -223,7 +223,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                             BasicRejectOptions { requeue: true },
                         )
                     }
-                }).wait().unwrap();
+                }).wait()?;
             }
             Err(_) => error!("Could not connect to redis"),
         }

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -83,7 +83,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .default_value("collection")
             .value_name("SET")
             .help("Specify the redis set to connect to"),
-    ).
+        ).
         arg(
             Arg::with_name("rabbitmq-routing-key")
                 .short("k")

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -133,6 +133,14 @@ fn main() -> Result<(), Box<dyn Error>> {
             .value_name("QUEUE")
             .help("Specify the RabbitMQ queue to connect to")
     ).arg(
+        Arg::with_name("rabbitmq-collection-queue")
+            .short("c")
+            .long("rmq-collection")
+            .env("SCRAPER_RABBITMQ_COLLECTION_QUEUE")
+            .default_value("collection")
+            .value_name("COLLECTION")
+            .help("Specify the RabbitMQ collection queue to connect to")
+    ).arg(
         Arg::with_name("redis-set")
             .short("s")
             .long("redis-set")
@@ -210,6 +218,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             args.value_of("rabbitmq-exchange").unwrap().to_string(),
             args.value_of("rabbitmq-routing-key").unwrap().to_string(),
             args.value_of("rabbitmq-queue").unwrap().to_string(),
+            args.value_of("rabbitmq-collection-queue").unwrap().to_string(),
             args.value_of("redis-set").unwrap().to_string(),
         )
         .expect("Failed to construct RMQRedisManager");

--- a/worker/src/rmqredis.rs
+++ b/worker/src/rmqredis.rs
@@ -52,7 +52,7 @@ pub struct RMQRedisManager {
     redis_addr: String,
     redis_port: u16,
     channel: Channel,
-    queue: Queue,
+    frontier_queue: Queue,
     exchange: String,
     routing_key: String,
     redis_set: String,
@@ -123,7 +123,7 @@ impl RMQRedisManager {
             redis_addr,
             redis_port,
             channel,
-            queue: frontier_queue,
+            frontier_queue,
             exchange,
             routing_key,
             redis_set,
@@ -150,7 +150,7 @@ impl Manager for RMQRedisManager {
     fn start_listening(&self, resolve_func: &dyn Fn(Task) -> TaskProcessResult) {
         self.channel
             .basic_consume(
-                &self.queue,
+                &self.frontier_queue,
                 "", //TODO
                 BasicConsumeOptions::default(),
                 FieldTable::default(),


### PR DESCRIPTION
The exchange and collection queue are binded together in the Worker. The Redis-Proxy needs to know about the existence of the the collection queue, which mean that it schouldn't care about the exchange and the bind between them. 