### PR TITLE
Cleanup of code and comments

### DIFF
--- a/.idea/scraper.iml
+++ b/.idea/scraper.iml
@@ -10,6 +10,12 @@
       <sourceFolder url="file://$MODULE_DIR$/proxy/examples" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/proxy/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/proxy/benches" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/worker\examples" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/worker\tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/worker\benches" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/proxy\examples" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/proxy\tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/proxy\benches" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/proxy/target" />
       <excludeFolder url="file://$MODULE_DIR$/worker/target" />
     </content>

--- a/.idea/scraper.iml
+++ b/.idea/scraper.iml
@@ -10,12 +10,6 @@
       <sourceFolder url="file://$MODULE_DIR$/proxy/examples" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/proxy/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/proxy/benches" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/worker\examples" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/worker\tests" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/worker\benches" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/proxy\examples" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/proxy\tests" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/proxy\benches" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/proxy/target" />
       <excludeFolder url="file://$MODULE_DIR$/worker/target" />
     </content>

--- a/proxy/src/task.rs
+++ b/proxy/src/task.rs
@@ -43,8 +43,8 @@ impl PartialEq for Task {
 // Allows Redis to automatically serialise Task into raw bytes with type inference
 impl ToRedisArgs for &Task {
     fn write_redis_args<W>(&self, out: &mut W)
-        where
-            W: ?Sized + RedisWrite,
+    where
+        W: ?Sized + RedisWrite,
     {
         out.write_arg(self.url.as_str().as_bytes())
     }

--- a/proxy/src/task.rs
+++ b/proxy/src/task.rs
@@ -2,16 +2,20 @@ use redis::{FromRedisValue, RedisError, RedisWrite, ToRedisArgs, Value};
 use std::io::{Error, ErrorKind};
 use url::Url;
 
+/// Tasks are the workload instances assigned to Workers. It describes a single Url that needs
+/// to be resolved by the web scraper.
 #[derive(Hash, Eq, Debug)]
 pub struct Task {
     pub url: Url,
 }
 
 impl Task {
+    /// Serialise the Task into bytes which makes it easier to transfer
     pub fn serialise(&self) -> Vec<u8> {
         self.url.as_str().as_bytes().to_vec()
     }
 
+    /// Deserialise a series of bytes into a Task
     pub fn deserialise(data: Vec<u8>) -> Result<Self, Error> {
         // checks if there is an error when changing data to a string
         let data_to_string_res = String::from_utf8(data);
@@ -30,6 +34,7 @@ impl Task {
 }
 
 impl PartialEq for Task {
+    // Two tasks are equal if they have the same Url
     fn eq(&self, other: &Self) -> bool {
         self.url == other.url
     }

--- a/worker/src/archive/rmq.rs
+++ b/worker/src/archive/rmq.rs
@@ -26,8 +26,7 @@ impl RabbitMQArchive {
     }
 }
 
-impl<D> Archive<D> for RabbitMQArchive
-    where D: Into<Vec<u8>> {
+impl<D> Archive<D> for RabbitMQArchive where D: Into<Vec<u8>> {
     fn archive_content(&self, content: D) -> ArchiveResult<()> {
         // Submit data to RabbitMQ
         let bytes = content.into();

--- a/worker/src/archive/rmq.rs
+++ b/worker/src/archive/rmq.rs
@@ -1,19 +1,19 @@
-use std::error::Error;
-
 use futures::Future;
 use lapin_futures::{BasicProperties, Channel};
 use lapin_futures::options::BasicPublishOptions;
 
-use crate::errors::{ArchiveError, ArchiveErrorKind, ArchiveResult};
+use crate::errors::{ArchiveError, ArchiveResult};
 use crate::traits::Archive;
 use crate::errors::ArchiveErrorKind::UnreachableError;
 
+#[allow(dead_code)]
 pub struct RabbitMQArchive {
     channel: Channel,
     exchange: String,
     routing_key: String,
 }
 
+#[allow(dead_code)]
 impl RabbitMQArchive {
     pub fn new(channel: Channel, exchange: String, routing_key: String) -> RabbitMQArchive {
         RabbitMQArchive {

--- a/worker/src/archive/rmq.rs
+++ b/worker/src/archive/rmq.rs
@@ -6,6 +6,7 @@ use crate::errors::{ArchiveError, ArchiveResult};
 use crate::traits::Archive;
 use crate::errors::ArchiveErrorKind::UnreachableError;
 
+/// The RabbitMQArchive is an Archive that stores the found data in a RabbitMQ queue
 #[allow(dead_code)]
 pub struct RabbitMQArchive {
     channel: Channel,
@@ -15,6 +16,7 @@ pub struct RabbitMQArchive {
 
 #[allow(dead_code)]
 impl RabbitMQArchive {
+    /// Construct a new RabbitMQArchive
     pub fn new(channel: Channel, exchange: String, routing_key: String) -> RabbitMQArchive {
         RabbitMQArchive {
             channel,
@@ -27,6 +29,7 @@ impl RabbitMQArchive {
 impl<D> Archive<D> for RabbitMQArchive
     where D: Into<Vec<u8>> {
     fn archive_content(&self, content: D) -> ArchiveResult<()> {
+        // Submit data to RabbitMQ
         let bytes = content.into();
         let res = self.channel.basic_publish(
             self.exchange.as_str(),

--- a/worker/src/defaultnormaliser.rs
+++ b/worker/src/defaultnormaliser.rs
@@ -10,7 +10,7 @@ use crate::errors::NormaliseErrorKind::ParsingError;
 pub struct DefaultNormaliser;
 
 impl Normaliser for DefaultNormaliser {
-    /// Normalising the tasks URL by setting scheme and path to lowercase,
+    /// Normalising the tasks Url by setting scheme and path to lowercase,
     /// removing the dot in path, removes hash from url and ordering the query.
     fn normalise(&self, url: Url) -> NormaliseResult<Url> {
         DefaultNormaliser::full_normalisation(url)

--- a/worker/src/defaultnormaliser.rs
+++ b/worker/src/defaultnormaliser.rs
@@ -5,6 +5,8 @@ use url_normalizer;
 use crate::errors::{NormaliseResult, NormaliseError};
 use crate::errors::NormaliseErrorKind::ParsingError;
 
+/// The DefaultNormaliser is a Normaliser that normalises URI's as described by
+/// RFC 3986 (https://tools.ietf.org/html/rfc3986) without changing the semantics.
 pub struct DefaultNormaliser;
 
 impl Normaliser for DefaultNormaliser {
@@ -20,8 +22,8 @@ impl DefaultNormaliser {
     fn full_normalisation(url: Url) -> NormaliseResult<Url> {
         let mut new_url = url;
 
-        //Normalising by ordering the query in alphabetic order,
-        //removes hash from url and changes encrypted to unencrypted.
+        // Normalising by ordering the query in alphabetic order,
+        // removes hash from url and changes encrypted to unencrypted.
         new_url = url_normalizer::normalize(new_url).map_err(|_| {
             NormaliseError::new(ParsingError, "Failed to normalise using url library", None)
         })?;
@@ -33,7 +35,7 @@ impl DefaultNormaliser {
         Ok(new_url)
     }
 
-    ///Sets the scheme and host to lowercase
+    /// Sets the scheme and host to lowercase
     fn scheme_and_host_to_lowercase(url: Url) -> NormaliseResult<Url> {
         let mut new_url = url;
 
@@ -107,11 +109,12 @@ impl DefaultNormaliser {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::task::Task;
 
     #[test]
     fn test_empty_path_to_slash() {
         let expected_url = "http://example.com/";
-        let mut test_task = Task {
+        let test_task = Task {
             url: Url::parse("http://example.com").unwrap()
         };
 
@@ -123,7 +126,7 @@ mod tests {
     #[test]
     fn test_converting_encoded_triplets_to_upper() {
         let expected_url = "http://example.com/foo%2A";
-        let mut test_task = Task {
+        let test_task = Task {
             url: Url::parse("http://example.com/foo%2a").unwrap()
         };
 
@@ -155,13 +158,7 @@ mod tests {
 
         let test_url = DefaultNormaliser::scheme_and_host_to_lowercase(test_task.url).unwrap();
 
-        let test_scheme = test_url.scheme();
-        let test_host = test_url.host_str().unwrap();
-
-        let expected_scheme = "https";
-        let expected_host = "sub.host.com";
-
-        assert_eq!(test_scheme, expected_scheme);
+        assert_eq!("https", test_url.scheme());
     }
 
     #[test]
@@ -173,13 +170,7 @@ mod tests {
 
         let test_url = DefaultNormaliser::scheme_and_host_to_lowercase(test_task.url).unwrap();
 
-        let test_scheme = test_url.scheme();
-        let test_host = test_url.host_str().unwrap();
-
-        let expected_scheme = "https";
-        let expected_host = "sub.host.com";
-
-        assert_eq!(test_host, expected_host);
+        assert_eq!("sub.host.com", test_url.host_str().unwrap());
     }
 
     #[test]

--- a/worker/src/defaultnormaliser.rs
+++ b/worker/src/defaultnormaliser.rs
@@ -1,12 +1,8 @@
-use crate::task::Task;
 use crate::traits::Normaliser;
 
-use std::error::Error;
-use std::fmt;
 use url::Url;
 use url_normalizer;
-use rand::seq::index::sample;
-use crate::errors::{NormaliseResult, NormaliseError, NormaliseErrorKind};
+use crate::errors::{NormaliseResult, NormaliseError};
 use crate::errors::NormaliseErrorKind::ParsingError;
 
 pub struct DefaultNormaliser;

--- a/worker/src/downloader.rs
+++ b/worker/src/downloader.rs
@@ -1,13 +1,12 @@
-use std::error::Error;
 use std::io::Read;
 
 use reqwest;
 use reqwest::Client;
 
-use crate::errors::{DownloadError, DownloadErrorKind, DownloadResult};
+use crate::errors::{DownloadError, DownloadResult};
+use crate::errors::DownloadErrorKind::{InvalidPage, NetworkError};
 use crate::task::Task;
 use crate::traits::Downloader;
-use crate::errors::DownloadErrorKind::{InvalidPage, NetworkError};
 
 /// A struct to access functions in downloader file
 /// Contains a reqwest client to send http requests

--- a/worker/src/errors.rs
+++ b/worker/src/errors.rs
@@ -14,7 +14,7 @@ pub enum ManagerErrorKind {
 pub enum DownloadErrorKind {
     NetworkError,        // No internet
     UnreachableError,    // No response
-    InvalidURL,          // URL is invalid
+    InvalidURL,          // Url is invalid
     InvalidPage,         // Could not make sense of downloaded material
 }
 

--- a/worker/src/errors.rs
+++ b/worker/src/errors.rs
@@ -6,14 +6,14 @@ use crate::traits::TaskProcessResult;
 #[derive(Debug)]
 pub enum ManagerErrorKind {
     NetworkError,        // No internet
-    UnreachableError,    // No responds
+    UnreachableError,    // No response
     InvalidTask,         // Task is not correct
 }
 
 #[derive(Debug)]
 pub enum DownloadErrorKind {
     NetworkError,        // No internet
-    UnreachableError,    // No responds
+    UnreachableError,    // No response
     InvalidURL,          // URL is invalid
     InvalidPage,         // Could not make sense of downloaded material
 }
@@ -31,7 +31,7 @@ pub enum NormaliseErrorKind {
 #[derive(Debug)]
 pub enum ArchiveErrorKind {
     NetworkError,        // No internet
-    UnreachableError,    // No responds
+    UnreachableError,    // No response
     ServerError,         // Backend received data, but was unable to process it
     InvalidData,         // Data is invalid
 }
@@ -236,8 +236,6 @@ impl Display for ArchiveErrorKind {
 
 #[cfg(test)]
 mod tests {
-    use std::fmt::Display;
-
     use crate::errors::{ArchiveError, ArchiveErrorKind, DownloadError, DownloadErrorKind, ExtractError, ExtractErrorKind, ManagerError, ManagerErrorKind, NormaliseError, NormaliseErrorKind};
 
     /// Testing formatting of ManagerError without source error

--- a/worker/src/extractor/html.rs
+++ b/worker/src/extractor/html.rs
@@ -7,6 +7,8 @@ use crate::errors::{ExtractError, ExtractResult};
 use crate::errors::ExtractErrorKind::ParsingError;
 use crate::traits::Extractor;
 
+/// The HTMLExtractorBase is an Extractor that converts a page of bytes (u8) to HTML and
+/// uses a HTMLExtractor to extract target data.
 pub struct HTMLExtractorBase<D, H: HTMLExtractor<D>> {
     _marker: PhantomData<D>,
     html_extractor: H,
@@ -27,6 +29,8 @@ where
 }
 
 impl<D, H: HTMLExtractor<D>> HTMLExtractorBase<D, H> {
+    /// Construct a new HTMLExtractorBase that extracts Urls and target data with the given
+    /// HTMLExtractor
     pub fn new(html_extractor: H) -> HTMLExtractorBase<D, H> {
         HTMLExtractorBase {
             _marker: PhantomData,
@@ -35,15 +39,19 @@ impl<D, H: HTMLExtractor<D>> HTMLExtractorBase<D, H> {
     }
 }
 
+/// An HTMLExtractor extracts Urls and data from HTML.
 pub trait HTMLExtractor<D> {
     fn extract_from_html(&self, content: Html, url: &Url) -> ExtractResult<(Vec<Url>, Vec<D>)>;
 }
 
+/// The HTMLLinkExtractor is a HTMLExtractor that only extracts links and no data. It finds
+/// Urls by taking the href attributes of the anchor tags. 
 pub struct HTMLLinkExtractor {
     link_selector: Selector,
 }
 
 impl HTMLLinkExtractor {
+    /// Construct a new HTMLLinkExtractor
     pub fn new() -> HTMLLinkExtractor {
         HTMLLinkExtractor {
             link_selector: Selector::parse("a").expect("anchor tag selector"),
@@ -57,6 +65,8 @@ impl HTMLExtractor<()> for HTMLLinkExtractor {
         content: Html,
         reference_url: &Url,
     ) -> ExtractResult<(Vec<Url>, Vec<()>)> {
+        // Extract no data
+        // Urls are found in the href attributes of anchor tags
         let tasks: Vec<Url> = content
             .select(&self.link_selector)
             .filter_map(|element| element.value().attr("href"))

--- a/worker/src/extractor/html.rs
+++ b/worker/src/extractor/html.rs
@@ -3,10 +3,9 @@ use std::marker::PhantomData;
 use scraper::{Html, Selector};
 use url::Url;
 
-use crate::errors::{ExtractError, ExtractErrorKind, ExtractResult};
-use crate::task::Task;
-use crate::traits::Extractor;
+use crate::errors::{ExtractError, ExtractResult};
 use crate::errors::ExtractErrorKind::ParsingError;
+use crate::traits::Extractor;
 
 pub struct HTMLExtractorBase<D, H: HTMLExtractor<D>> {
     _marker: PhantomData<D>,

--- a/worker/src/filter/filter.rs
+++ b/worker/src/filter/filter.rs
@@ -13,19 +13,20 @@ impl Filter for NoFilter {
     }
 }
 
-/// Contains a Vec of all the entries in the path given
+/// A Blacklist is a Filter that will cull specific URLs
 pub(crate) struct Blacklist {
     urls: Vec<String>,
 }
 
 impl Blacklist {
-    /// Constructor for blacklist struct. Automatically reads from path and puts urls into struct
+    /// Construct a Blacklist from a file or blacklisted URL substrings
     pub fn new(path: String) -> Self {
         Blacklist {
             urls: read_filter_from_file((&path).to_string()),
         }
     }
-    /// Private constructor for unit testing
+
+    /// Construct a Blacklist from a Vec of URL substrings
     #[cfg(test)]
     fn new_from_vec(urls: Vec<String>) -> Self {
         Blacklist { urls }
@@ -33,13 +34,11 @@ impl Blacklist {
 }
 
 impl Filter for Blacklist {
-    /// Takes a task and returns false if the task's url exists in blacklist file, else true
+    /// Returns true if the task's url is blacklisted
     fn filter(&self, task: &Task) -> bool {
-        // Assign host url as string to variable if possible, else return true
         if let Some(host_url) = task.url.host_str() {
             let host_url = host_url.to_string();
-            /* Iterates through blacklist and sees if the host_url contains a substring of any
-            entry in the list, therefore checks all paths and sub-domains*/
+            // Check if the host_url contains a blacklisted substring
             for url in &self.urls {
                 if host_url.contains(url) {
                     return false;
@@ -51,19 +50,19 @@ impl Filter for Blacklist {
     }
 }
 
-/// Contains a Vec of all the entries in the path given
+/// A Whitelist is a Filter that only allows certain URLs
 pub(crate) struct Whitelist {
     urls: Vec<String>,
 }
 
 impl Whitelist {
-    /// Constructor for whitelist struct. Automatically reads from path and puts urls into struct
+    /// Construct a Whitelist from a file or whitelisted URL substrings
     pub fn new(path: String) -> Self {
         Whitelist {
             urls: read_filter_from_file((&path).to_string()),
         }
     }
-    /// Private constructor for unit testing
+    /// Construct a Whitelist from a Vec of URL substrings
     #[cfg(test)]
     fn new_from_vec(urls: Vec<String>) -> Self {
         Whitelist { urls }
@@ -71,13 +70,11 @@ impl Whitelist {
 }
 
 impl Filter for Whitelist {
-    /// Takes a task and returns true if the task's url exists in whitelist file, else false
+    /// Returns true if the task's url is whitelisted
     fn filter(&self, task: &Task) -> bool {
-        // If there is a host string assign this to host-url, else return false
         if let Some(host_url) = task.url.host_str() {
             let host_url = host_url.to_string();
-            /* Iterates through whitelist and sees if the host_url contains a substring of any
-            entry in the whitelist, therefore all paths and sub-domains*/
+            // Check if the host_url contains a whitelisted substring
             for url in &self.urls {
                 if host_url.contains(url) {
                     return true;

--- a/worker/src/filter/filter.rs
+++ b/worker/src/filter/filter.rs
@@ -8,7 +8,7 @@ use crate::traits::Filter;
 pub(crate) struct NoFilter;
 
 impl Filter for NoFilter {
-    fn filter(&self, task: &Task) -> bool {
+    fn filter(&self, _task: &Task) -> bool {
         true
     }
 }

--- a/worker/src/filter/filter.rs
+++ b/worker/src/filter/filter.rs
@@ -13,20 +13,20 @@ impl Filter for NoFilter {
     }
 }
 
-/// A Blacklist is a Filter that will cull specific URLs
+/// A Blacklist is a Filter that will cull specific Urls
 pub(crate) struct Blacklist {
     urls: Vec<String>,
 }
 
 impl Blacklist {
-    /// Construct a Blacklist from a file or blacklisted URL substrings
+    /// Construct a Blacklist from a file or blacklisted Url substrings
     pub fn new(path: String) -> Self {
         Blacklist {
             urls: read_filter_from_file((&path).to_string()),
         }
     }
 
-    /// Construct a Blacklist from a Vec of URL substrings
+    /// Construct a Blacklist from a Vec of Url substrings
     #[cfg(test)]
     fn new_from_vec(urls: Vec<String>) -> Self {
         Blacklist { urls }
@@ -50,19 +50,19 @@ impl Filter for Blacklist {
     }
 }
 
-/// A Whitelist is a Filter that only allows certain URLs
+/// A Whitelist is a Filter that only allows certain Urls
 pub(crate) struct Whitelist {
     urls: Vec<String>,
 }
 
 impl Whitelist {
-    /// Construct a Whitelist from a file or whitelisted URL substrings
+    /// Construct a Whitelist from a file or whitelisted Url substrings
     pub fn new(path: String) -> Self {
         Whitelist {
             urls: read_filter_from_file((&path).to_string()),
         }
     }
-    /// Construct a Whitelist from a Vec of URL substrings
+    /// Construct a Whitelist from a Vec of Url substrings
     #[cfg(test)]
     fn new_from_vec(urls: Vec<String>) -> Self {
         Whitelist { urls }
@@ -136,34 +136,34 @@ mod tests {
     use crate::task::Task;
     use crate::traits::Filter;
 
-    /// Setup vector of URLs as Strings for testing
+    /// Setup vector of Urls as Strings for testing
     fn get_predefined_list() -> Vec<String> {
         // Create a vec of Strings, by mapping to strings and lastly collecting
         vec!["reddit.com", "bbc.co.uk", "dr.dk"].iter().map(|f| f.to_string()).collect()
     }
 
-    /// Test that looking up a URL that is contained in whitelist returns true
+    /// Test that looking up a Url that is contained in whitelist returns true
     #[test]
     fn whitelist_test_01() {
         let whitelist = Whitelist::new_from_vec(get_predefined_list());
         assert!(whitelist.filter(&Task { url: Url::parse("http://reddit.com").unwrap() }))
     }
 
-    /// Test that looking up a URL that is NOT contained in whitelist returns false
+    /// Test that looking up a Url that is NOT contained in whitelist returns false
     #[test]
     fn whitelist_test_02() {
         let whitelist = Whitelist::new_from_vec(get_predefined_list());
         assert!(!whitelist.filter(&Task { url: Url::parse("http://tv2.dk").unwrap() }))
     }
 
-    /// Test that looking up a URL that is contained in blacklist returns false
+    /// Test that looking up a Url that is contained in blacklist returns false
     #[test]
     fn blacklist_test_01() {
         let blacklist = Blacklist::new_from_vec(get_predefined_list());
         assert!(!blacklist.filter(&Task { url: Url::parse("http://reddit.com").unwrap() }))
     }
 
-    /// Test that looking up a URL that is NOT contained in blacklist returns true
+    /// Test that looking up a Url that is NOT contained in blacklist returns true
     #[test]
     fn blacklist_test_02() {
         let blacklist = Blacklist::new_from_vec(get_predefined_list());

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -117,20 +117,12 @@ fn main() -> Result<(), Box<dyn Error>> {
             .help("Specify the RabbitMQ exchange to connect to")
     ).arg(
         Arg::with_name("rabbitmq-prefetch-count")
-            .short("c")
+            .short("n")
             .long("rmq-prefetch-count")
             .env("SCRAPER_RABBITMQ_PREFETCH_COUNT")
             .default_value("5")
             .value_name("COUNT")
             .help("Specify the number of tasks to prefetch")
-    ).arg(
-        Arg::with_name("rabbitmq-routing-key")
-            .short("k")
-            .long("rmq-routing-key")
-            .env("SCRAPER_RABBITMQ_ROUTING_KEY")
-            .default_value("") // No routing-key by default
-            .value_name("KEY")
-            .help("Specify the RabbitMQ routing-key to connect to")
     ).arg(
         Arg::with_name("rabbitmq-queue")
             .short("q")
@@ -226,7 +218,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             args.value_of("redis-port").unwrap().parse().expect("Failed parsing Redis port to u16"), // Parse str to u16
             args.value_of("rabbitmq-exchange").unwrap().to_string(),
             args.value_of("rabbitmq-prefetch-count").unwrap().parse().expect("Failed parsing prefetch count to u16"), // Parse str to u16
-            args.value_of("rabbitmq-routing-key").unwrap().to_string(),
             args.value_of("rabbitmq-queue").unwrap().to_string(),
             args.value_of("rabbitmq-collection-queue").unwrap().to_string(),
             args.value_of("redis-set").unwrap().to_string(),

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -11,12 +11,11 @@ extern crate tokio;
 use std::error::Error;
 use std::io::ErrorKind;
 
-use clap::{App, AppSettings, Arg, ArgMatches};
-use log::Level;
+use clap::{App, Arg};
 use log::LevelFilter;
 use log4rs::append::console::ConsoleAppender;
 use log4rs::append::file::FileAppender;
-use log4rs::config::{Appender, Config, Logger, Root};
+use log4rs::config::{Appender, Config, Root};
 use log4rs::encode::pattern::PatternEncoder;
 
 use crate::defaultnormaliser::DefaultNormaliser;
@@ -204,19 +203,21 @@ fn main() -> Result<(), Box<dyn Error>> {
         },
     )) {
         info!(
-            "Starting worker module using RabbitMQ({:?}) and redis({:?})",
+            "Starting worker module using RabbitMQ({}:{}) and redis({}:{})",
             args.value_of("rmq-address").unwrap().to_string(),
-            args.value_of("redis-address").unwrap().to_string()
+            args.value_of("rabbitmq-port").unwrap().to_string(),
+            args.value_of("redis-address").unwrap().to_string(),
+            args.value_of("redis-port").unwrap().to_string(),
         );
 
         // Construct a worker and its components
         let manager = RMQRedisManager::new(
             args.value_of("rmq-address").unwrap().to_string(),
-            args.value_of("rabbitmq-port").unwrap().parse().unwrap(), // Parse str to u16
+            args.value_of("rabbitmq-port").unwrap().parse().expect("Failed parsing Rabbitmq port to u16"), // Parse str to u16
             args.value_of("redis-address").unwrap().to_string(),
-            args.value_of("redis-port").unwrap().parse().unwrap(), // Parse str to u16
+            args.value_of("redis-port").unwrap().parse().expect("Failed parsing Redis port to u16"), // Parse str to u16
             args.value_of("rabbitmq-exchange").unwrap().to_string(),
-            args.value_of("rabbitmq-prefetch-count").unwrap().parse().unwrap(), // Parse str to u16
+            args.value_of("rabbitmq-prefetch-count").unwrap().parse().expect("Failed parsing prefetch count to u16"), // Parse str to u16
             args.value_of("rabbitmq-routing-key").unwrap().to_string(),
             args.value_of("rabbitmq-queue").unwrap().to_string(),
             args.value_of("redis-set").unwrap().to_string(),

--- a/worker/src/rmqredis.rs
+++ b/worker/src/rmqredis.rs
@@ -41,6 +41,10 @@ impl FromRedisValue for Task {
     }
 }
 
+/// The RMQRedisManager is a Manager for a distributed web crawler that uses RabbitMQ and Redis.
+/// Tasks are submitted to a RMQ exchange and received from a RMQ queue.
+/// When checking if a task has already been submitted, the RQMRedisManager will ask Redis if
+/// the task is in a given set.
 pub struct RMQRedisManager {
     rmq_addr: String,
     rmq_port: u16,
@@ -55,6 +59,7 @@ pub struct RMQRedisManager {
 }
 
 impl RMQRedisManager {
+    /// Construct a new RMQRedisManager
     pub fn new(
         rmq_addr: String,
         rmq_port: u16,
@@ -121,6 +126,7 @@ impl RMQRedisManager {
 }
 
 impl Manager for RMQRedisManager {
+    /// Submit a new task. The task must be checked if new before submission.
     fn submit_task(&self, task: &Task) -> ManagerResult<()> {
         let result = self
             .channel
@@ -136,6 +142,7 @@ impl Manager for RMQRedisManager {
         result.map_err(|e| ManagerError::new(UnreachableError, "Could not reach manager.", Some(Box::new(e))))
     }
 
+    /// Start resolving tasks with the given resolve function
     fn start_listening(&self, resolve_func: &dyn Fn(Task) -> TaskProcessResult) {
         self.channel
             .basic_consume(
@@ -145,26 +152,27 @@ impl Manager for RMQRedisManager {
                 FieldTable::default(),
             )
             .and_then(move |consumer| {
-                consumer.for_each(move |delivery| {
-                    let task_res = Task::deserialise(delivery.data);
-                    match task_res {
+                // Resolve each message received
+                consumer.for_each(move |msg| {
+                    match Task::deserialise(msg.data) {
                         Err(_) => {
-                            self.channel.basic_reject(delivery.delivery_tag, BasicRejectOptions { requeue: false })
+                            // Deserialisation failed. Discard the task
+                            self.channel.basic_reject(msg.delivery_tag, BasicRejectOptions::default())
                         }
                         Ok(task) => {
-                            let result = resolve_func(task);
-                            match result {
+                            // Resolve task
+                            match resolve_func(task) {
                                 TaskProcessResult::Ok => {
-                                    self.channel.basic_ack(delivery.delivery_tag, false)
+                                    self.channel.basic_ack(msg.delivery_tag, false)
                                 }
                                 TaskProcessResult::Err => self
                                     .channel
                                     // Do not requeue task if error is met
-                                    .basic_reject(delivery.delivery_tag, BasicRejectOptions { requeue: false }),
+                                    .basic_reject(msg.delivery_tag, BasicRejectOptions::default()),
                                 TaskProcessResult::Reject => self
                                     .channel
-                                    // Do requeue task if error is met
-                                    .basic_reject(delivery.delivery_tag, BasicRejectOptions { requeue: true }),
+                                    // Requeue task if error is met
+                                    .basic_reject(msg.delivery_tag, BasicRejectOptions::default()),
                             }
                         }
                     }
@@ -174,16 +182,19 @@ impl Manager for RMQRedisManager {
             .unwrap();
     }
 
+    /// Closes the manager and its connections
     fn close(self) -> ManagerResult<()> {
-        self.channel.close(0, "called close()");
+        self.channel.close(0, "Manager was closed by calling close()");
         Ok(())
     }
 
+    /// Checks if a task has already been submitted
     fn contains(&self, task: &Task) -> ManagerResult<bool> {
         let client_result =
             redis::Client::open(format!("redis://{}:{}/", self.redis_addr, self.redis_port).as_str());
         if let Ok(client) = client_result {
             if let Ok(mut con) = client.get_connection() {
+                // Check if the task is a member of the collection
                 let found_result = con.sismember(self.redis_set.as_str(), task);
                 if let Ok(found) = found_result {
                     return Ok(found);

--- a/worker/src/split.rs
+++ b/worker/src/split.rs
@@ -2,15 +2,22 @@ use crate::errors::ManagerResult;
 use crate::Task;
 use crate::traits::{Collection, Frontier, Manager, TaskProcessResult};
 
+/// A SplitManager is a manager that consists of a separate frontier and Collection. I.e. this can
+/// be used then there are no dependencies between the frontier implementation and the
+/// collection implementation.
+/// When a task is submitted, it is submitted to the frontier first and secondly the collection.
+/// Since submitting to the frontier and the collection can fail, the task is not guaranteed to
+/// submitted to the collection, even if was successfully submitted to the frontier.
 #[allow(dead_code)]
-struct SplitManager<F: Frontier, S: Collection> {
-    frontier: F,
-    collection: S,
+struct SplitManager {
+    frontier: Box<dyn Frontier>,
+    collection: Box<dyn Collection>,
 }
 
 #[allow(dead_code)]
-impl<F: Frontier, S: Collection> SplitManager<F, S> {
-    fn new(frontier: F, collection: S) -> Self {
+impl SplitManager {
+    /// Construct a new SplitManager with the given Frontier and Collection
+    fn new(frontier: Box<dyn Frontier>, collection: Box<dyn Collection>) -> Self {
         SplitManager {
             frontier,
             collection,
@@ -18,21 +25,28 @@ impl<F: Frontier, S: Collection> SplitManager<F, S> {
     }
 }
 
-impl<F: Frontier, S: Collection> Manager for SplitManager<F, S> {
+impl Manager for SplitManager {
+    /// Submits a task to the Frontier and the Collection.
+    /// When a task is submitted, it is submitted to the frontier first and secondly the collection.
+    /// Since submitting to the frontier and the collection can fail, the task is not guaranteed to
+    /// submitted to the collection, even if was successfully submitted to the frontier.
     fn submit_task(&self, task: &Task) -> ManagerResult<()> {
-        // Can we make any atomicity guarantees?
         self.frontier.submit_task(task)?;
         self.collection.submit_task(task)
     }
 
+    /// Starts resolving Task with the given resolve function
     fn start_listening(&self, resolve_func: &dyn Fn(Task) -> TaskProcessResult) {
         self.frontier.start_listening(resolve_func)
     }
 
+    /// Closes the SplitManager and any open connections that the Frontier may have
     fn close(self) -> ManagerResult<()> {
-        self.frontier.close()
+        self.frontier.close()?;
+        Ok(())
     }
 
+    /// Checks if a Task has already been submitted
     fn contains(&self, task: &Task) -> ManagerResult<bool> {
         self.collection.contains(task)
     }

--- a/worker/src/split.rs
+++ b/worker/src/split.rs
@@ -2,11 +2,13 @@ use crate::errors::ManagerResult;
 use crate::Task;
 use crate::traits::{Collection, Frontier, Manager, TaskProcessResult};
 
+#[allow(dead_code)]
 struct SplitManager<F: Frontier, S: Collection> {
     frontier: F,
     collection: S,
 }
 
+#[allow(dead_code)]
 impl<F: Frontier, S: Collection> SplitManager<F, S> {
     fn new(frontier: F, collection: S) -> Self {
         SplitManager {

--- a/worker/src/task.rs
+++ b/worker/src/task.rs
@@ -1,16 +1,20 @@
 use url::Url;
 use crate::errors::{ManagerError, ManagerErrorKind, ManagerResult};
 
+/// Tasks are the workload instances assigned to Workers. It describes a single Url that needs
+/// to be resolved by the web scraper.
 #[derive(Hash, Eq, Debug)]
 pub struct Task {
     pub url: Url,
 }
 
 impl Task {
+    /// Serialise the Task into bytes which makes it easier to transfer
     pub fn serialise(&self) -> Vec<u8> {
         self.url.as_str().as_bytes().to_vec()
     }
 
+    /// Deserialise a series of bytes into a Task
     pub fn deserialise(data: Vec<u8>) -> ManagerResult<Self> {
         let data_to_string_res = String::from_utf8(data);
         // checks if there is an error when changing data to a string
@@ -29,6 +33,7 @@ impl Task {
 }
 
 impl PartialEq for Task {
+    // Two tasks are equal if they have the same Url
     fn eq(&self, other: &Self) -> bool {
         self.url == other.url
     }

--- a/worker/src/task.rs
+++ b/worker/src/task.rs
@@ -68,7 +68,7 @@ mod tests {
         assert_ne!(task1_regen, task2_regen);
     }
 
-    /// Equality between two identical URLs
+    /// Equality between two identical Urls
     #[test]
     fn normalisation_equality_1() {
         let task1 = task::Task { url: Url::parse("http://aau.dk").unwrap() };
@@ -100,7 +100,7 @@ mod tests {
         assert_ne!(task1, task2)
     }
 
-    /// Domain labels change semantics and as such these two URLs are inequal
+    /// Domain labels change semantics and as such these two Urls are inequal
     #[test]
     fn normalisation_inequality_2() {
         let task1 = task::Task { url: Url::parse("https://aau.dk").unwrap() };

--- a/worker/src/traits.rs
+++ b/worker/src/traits.rs
@@ -45,7 +45,7 @@ pub trait Downloader<S> {
     fn fetch_page(&self, task: &Task) -> DownloadResult<S>;
 }
 
-/// The Extractor extracts new URLs and target data D from the page S
+/// The Extractor extracts new Urls and target data D from the page S
 pub trait Extractor<S, D> {
     fn extract_content(&self, page: S, url: &Url) -> ExtractResult<(Vec<Url>, Vec<D>)>;
 }
@@ -61,7 +61,7 @@ pub trait Archive<D> {
     fn archive_content(&self, content: D) -> ArchiveResult<()>;
 }
 
-/// The Normaliser normalises URLs to avoid different URLs to the same page
+/// The Normaliser normalises URLs to avoid different Urls to the same page
 pub trait Normaliser {
     fn normalise(&self, url: Url) -> NormaliseResult<Url>;
 }

--- a/worker/src/traits.rs
+++ b/worker/src/traits.rs
@@ -1,5 +1,3 @@
-use std::error::Error;
-
 use url::Url;
 
 use crate::errors::{ArchiveResult, DownloadResult, ExtractResult, ManagerResult, NormaliseResult};

--- a/worker/src/traits.rs
+++ b/worker/src/traits.rs
@@ -3,6 +3,7 @@ use url::Url;
 use crate::errors::{ArchiveResult, DownloadResult, ExtractResult, ManagerResult, NormaliseResult};
 use crate::task::Task;
 
+/// A Manager serves as the interface to the frontier and the collection
 pub trait Manager {
     fn submit_task(&self, task: &Task) -> ManagerResult<()>;
 
@@ -13,42 +14,54 @@ pub trait Manager {
     fn contains(&self, task: &Task) -> ManagerResult<bool>;
 }
 
+/// A Frontier contains upcoming tasks
 pub trait Frontier {
     fn submit_task(&self, task: &Task) -> ManagerResult<()>;
 
     fn start_listening(&self, resolve_func: &dyn Fn(Task) -> TaskProcessResult);
 
-    fn close(self) -> ManagerResult<()>;
+    fn close(self: Box<Self>) -> ManagerResult<()>;
 }
 
+/// When resolving a task, there are three different outcomes:
+/// Ok: Task was completed
+/// Err: Task was erroneous and should be discarded.
+/// Reject: Task could not be completed this time. Let it be rescheduled.
 pub enum TaskProcessResult {
     Ok,
     Err,
     Reject,
 }
 
+/// A Collection contains every found task, which prevents work duplications
 pub trait Collection {
     fn contains(&self, task: &Task) -> ManagerResult<bool>;
 
     fn submit_task(&self, task: &Task) -> ManagerResult<()>;
 }
 
+/// The Downloader downloads the page S associated with the given task
 pub trait Downloader<S> {
     fn fetch_page(&self, task: &Task) -> DownloadResult<S>;
 }
 
+/// The Extractor extracts new URLs and target data D from the page S
 pub trait Extractor<S, D> {
     fn extract_content(&self, page: S, url: &Url) -> ExtractResult<(Vec<Url>, Vec<D>)>;
 }
 
+/// The Filter selects which tasks to visit. When the `filter` method returns true, the task should
+/// be resolved.
 pub trait Filter {
     fn filter(&self, task: &Task) -> bool;
 }
 
+/// The Archive stores the target data D
 pub trait Archive<D> {
     fn archive_content(&self, content: D) -> ArchiveResult<()>;
 }
 
+/// The Normaliser normalises URLs to avoid different URLs to the same page
 pub trait Normaliser {
     fn normalise(&self, url: Url) -> NormaliseResult<Url>;
 }

--- a/worker/src/void.rs
+++ b/worker/src/void.rs
@@ -5,7 +5,7 @@ use crate::traits::Archive;
 pub struct Void;
 
 impl<D> Archive<D> for Void {
-    fn archive_content(&self, content: D) -> ArchiveResult<()> {
+    fn archive_content(&self, _content: D) -> ArchiveResult<()> {
         Ok(())
     }
 }

--- a/worker/src/void.rs
+++ b/worker/src/void.rs
@@ -1,7 +1,7 @@
 use crate::errors::ArchiveResult;
 use crate::traits::Archive;
 
-///Functions as an Archive but is doing nothing with the content.
+/// A Void is an Archive that does not store the given data
 pub struct Void;
 
 impl<D> Archive<D> for Void {

--- a/worker/src/worker.rs
+++ b/worker/src/worker.rs
@@ -23,8 +23,7 @@ pub struct Worker<S, D> {
     _data_type_marker: PhantomData<D>,
 }
 
-
-impl<'a, S, D> Worker<S, D> {
+impl<S, D> Worker<S, D> {
     /// Create a new worker with the given components.
     pub fn new(
         name: &str,


### PR DESCRIPTION
- Removed unused imports and variables.
- Added `allow(dead_code)` where reasonable, e.g. `SplitManager`
- Boxed `SplitManagers` fields so any `Frontier` and `Collection` can be used
- Cleanup of code snippets and adhering to Rust idioms
- Improve comments and added a ton more
- Fixed bug where two args both had `-c` as short name