### PR TITLE
made the trait Archive take Vec<D> instead of only D

### DIFF
--- a/worker/src/archive/rmq.rs
+++ b/worker/src/archive/rmq.rs
@@ -26,7 +26,7 @@ impl RabbitMQArchive {
     }
 }
 
-impl<D> Archive<D> for RabbitMQArchive where std::vec::Vec<u8>: std::convert::From<std::vec::Vec<D>> {
+impl<D> Archive<D> for RabbitMQArchive where Vec<u8>: From<Vec<D>> {
     fn archive_content(&self, content: Vec<D>) -> ArchiveResult<()> {
         // Submit data to RabbitMQ
         let bytes = content.into();

--- a/worker/src/archive/rmq.rs
+++ b/worker/src/archive/rmq.rs
@@ -26,8 +26,8 @@ impl RabbitMQArchive {
     }
 }
 
-impl<D> Archive<D> for RabbitMQArchive where D: Into<Vec<u8>> {
-    fn archive_content(&self, content: D) -> ArchiveResult<()> {
+impl<D> Archive<D> for RabbitMQArchive where std::vec::Vec<u8>: std::convert::From<std::vec::Vec<D>> {
+    fn archive_content(&self, content: Vec<D>) -> ArchiveResult<()> {
         // Submit data to RabbitMQ
         let bytes = content.into();
         let res = self.channel.basic_publish(

--- a/worker/src/traits.rs
+++ b/worker/src/traits.rs
@@ -58,7 +58,7 @@ pub trait Filter {
 
 /// The Archive stores the target data D
 pub trait Archive<D> {
-    fn archive_content(&self, content: D) -> ArchiveResult<()>;
+    fn archive_content(&self, content: Vec<D>) -> ArchiveResult<()>;
 }
 
 /// The Normaliser normalises URLs to avoid different Urls to the same page

--- a/worker/src/void.rs
+++ b/worker/src/void.rs
@@ -5,7 +5,7 @@ use crate::traits::Archive;
 pub struct Void;
 
 impl<D> Archive<D> for Void {
-    fn archive_content(&self, _content: D) -> ArchiveResult<()> {
+    fn archive_content(&self, _content: Vec<D>) -> ArchiveResult<()> {
         Ok(())
     }
 }

--- a/worker/src/worker.rs
+++ b/worker/src/worker.rs
@@ -68,12 +68,11 @@ impl<S, D> Worker<S, D> {
                         }
                         Ok((mut urls, data)) => {
                             // Archiving
-                            for datum in data {
-                                if let Err(e) = self.archive.archive_content(datum) {
-                                    error!("{} failed archiving some data. {}", self.name, e);
-                                    return TaskProcessResult::from(e)
-                                }
+                            if let Err(e) = self.archive.archive_content(data ) {
+                                error!("{} failed archiving some data. {}", self.name, e);
+                                return TaskProcessResult::from(e)
                             }
+
 
                             // Normalise extracted links
                             // After normalisation, squash urls into a hash set to remove duplicates


### PR DESCRIPTION
the content saved to archive is send in batches instead of as a single element. 
this solves issue #89 