### PR TITLE
Added sentinel Redis functionality

### DIFF
--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -140,6 +140,13 @@ fn main() -> Result<(), Box<dyn Error>> {
             .value_name("COLLECTION")
             .help("Specify the RabbitMQ collection queue to connect to")
     ).arg(
+        Arg::with_name("sentinel")
+            .long("sentinel")
+            .env("SCRAPER_SENTINEL")
+            .default_value("true")
+            .value_name("BOOLEAN")
+            .help("Specify whether to use a sentinel redis connection or not")
+    ).arg(
         Arg::with_name("redis-set")
             .short("s")
             .long("redis-set")
@@ -221,6 +228,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             args.value_of("rabbitmq-queue").unwrap().to_string(),
             args.value_of("rabbitmq-collection-queue").unwrap().to_string(),
             args.value_of("redis-set").unwrap().to_string(),
+            args.value_of("sentinel").unwrap().parse().expect("The sentinel argument was not a boolean")
         )
         .expect("Failed to construct RMQRedisManager");
         let downloader = DefaultDownloader::new();

--- a/worker/src/rmqredis.rs
+++ b/worker/src/rmqredis.rs
@@ -249,7 +249,7 @@ impl Manager for RMQRedisManager {
 
     /// Checks if a task has already been submitted
     fn contains(&self, task: &Task) -> ManagerResult<bool> {
-        let mut con = self.redis_connection.lock().expect("Redis connection mutex was corruption");
+        let mut con = self.redis_connection.lock().expect("Redis connection mutex was corrupted");
 
         // Check if the task is a member of the collection
         con.sismember(self.redis_set.as_str(), task)
@@ -257,7 +257,7 @@ impl Manager for RMQRedisManager {
     }
 }
 
-/// Establishes a redis connection. It if is sentinel it connects to the master group named 'master'
+/// Establishes a redis connection. If it is a sentinel it connects to the master group named 'master'
 fn create_redis_connection(connection_info: ConnectionInfo, sentinel: bool) -> Result<Connection, RedisError> {
     let mut client = redis::Client::open(connection_info.clone())?;
 


### PR DESCRIPTION
The connection to Redis can now be sentinel. In other words, if a Redis node dies, our worker client knows how to connect to a new one.

However, when we run locally, we don't have a sentinel server, so we can't establish a sentinel connection to it. In that case we should set the commandline argument `sentinel=false` or the environment variable `SCRAPER_SENTINEL=false`.

@jenrik test this on the servers please.

Resolves #47 