### PR TITLE
Made Manager traits take a Vec<Task> and adjusted accordingly

### DIFF
--- a/worker/src/rmqredis.rs
+++ b/worker/src/rmqredis.rs
@@ -8,7 +8,7 @@ use lapin_futures::options::{
     QueueBindOptions, QueueDeclareOptions, BasicQosOptions,
 };
 use lapin_futures::types::FieldTable;
-use redis::{Commands, Connection, ConnectionAddr, FromRedisValue, RedisError, RedisWrite, ToRedisArgs, Value, ConnectionInfo, IntoConnectionInfo, RedisResult};
+use redis::{Connection, ConnectionAddr, FromRedisValue, RedisError, RedisWrite, ToRedisArgs, Value, ConnectionInfo, IntoConnectionInfo, RedisResult, PipelineCommands};
 
 use crate::errors::{ManagerError, ManagerResult};
 use crate::errors::ManagerErrorKind::UnreachableError;
@@ -16,6 +16,8 @@ use crate::task::Task;
 use crate::traits::{Manager, TaskProcessResult};
 use std::error::Error;
 use std::fmt::{Display, Formatter};
+use std::ops::DerefMut;
+use std::borrow::BorrowMut;
 
 // Allows Redis to automatically serialise Task into raw bytes with type inference
 impl ToRedisArgs for &Task {
@@ -185,24 +187,30 @@ impl RMQRedisManager {
 }
 
 impl Manager for RMQRedisManager {
-    /// Submit a new task. The task must be checked if new before submission.
-    fn submit_task(&self, task: &Task) -> ManagerResult<()> {
-        let result = self
-            .channel
-            .basic_publish(
-                self.exchange.as_str(),
-                "",
-                task.serialise(),
-                BasicPublishOptions::default(),
-                BasicProperties::default(),
-            )
-            .wait();
+    /// Submit new tasks. The tasks must be checked if new before submission.
+    fn submit(&self, tasks: Vec<Task>) -> ManagerResult<()> {
+        // Publish each task. If one fails, abort
+        for task in tasks.iter() {
+            let result = self.channel
+                .basic_publish(
+                    self.exchange.as_str(),
+                    "",
+                    task.serialise(),
+                    BasicPublishOptions::default(),
+                    BasicProperties::default(),
+                )
+                .wait();
 
-        result.map_err(|e| ManagerError::new(UnreachableError, "Could not reach manager.", Some(Box::new(e))))
+            if let Err(e) = result {
+                return Err(ManagerError::new(UnreachableError, "Could not reach manager.", Some(Box::new(e))))
+            }
+        }
+
+        Ok(())
     }
 
     /// Start resolving tasks with the given resolve function
-    fn start_listening(&self, resolve_func: &dyn Fn(Task) -> TaskProcessResult) {
+    fn subscribe(&self, resolve_func: &dyn Fn(Task) -> TaskProcessResult) {
         self.channel
             .basic_consume(
                 &self.frontier_queue,
@@ -244,16 +252,34 @@ impl Manager for RMQRedisManager {
     /// Closes the manager and its connections
     fn close(self) -> ManagerResult<()> {
         self.channel.close(0, "Manager was closed by calling close()");
+        // Redis connection does not have to be closed
         Ok(())
     }
 
-    /// Checks if a task has already been submitted
-    fn contains(&self, task: &Task) -> ManagerResult<bool> {
+    /// Cull tasks that have already been submitted once
+    fn cull_known(&self, mut tasks: Vec<Task>) -> ManagerResult<Vec<Task>> {
         let mut con = self.redis_connection.lock().expect("Redis connection mutex was corruption");
 
-        // Check if the task is a member of the collection
-        con.sismember(self.redis_set.as_str(), task)
-            .map_err(|e| ManagerError::new(UnreachableError, "Could not reach manager.", Some(Box::new(e))))
+        // Query Redis about membership
+        let reset_set = self.redis_set.as_str();
+        let mut pipeline = redis::pipe();
+        for task in tasks.iter() {
+            pipeline.sismember(reset_set, task);
+        }
+        let is_member_vec: Vec<bool> = pipeline.query(con.deref_mut())
+            .map_err(|e| ManagerError::new(UnreachableError, "Could not reach manager.", Some(Box::new(e))))?;
+
+        // Remove those that are already members of the collection
+        Ok(tasks.drain(..)
+            .zip(is_member_vec)
+            .filter_map(|(task, is_member)| {
+                if !is_member {
+                    Some(task)
+                } else {
+                    None
+                }
+            })
+            .collect())
     }
 }
 

--- a/worker/src/task.rs
+++ b/worker/src/task.rs
@@ -3,7 +3,7 @@ use crate::errors::{ManagerError, ManagerErrorKind, ManagerResult};
 
 /// Tasks are the workload instances assigned to Workers. It describes a single Url that needs
 /// to be resolved by the web scraper.
-#[derive(Hash, Eq, Debug)]
+#[derive(Hash, Eq, Debug, Clone)]
 pub struct Task {
     pub url: Url,
 }

--- a/worker/src/traits.rs
+++ b/worker/src/traits.rs
@@ -5,20 +5,20 @@ use crate::task::Task;
 
 /// A Manager serves as the interface to the frontier and the collection
 pub trait Manager {
-    fn submit_task(&self, task: &Task) -> ManagerResult<()>;
+    fn submit(&self, tasks: Vec<Task>) -> ManagerResult<()>;
 
-    fn start_listening(&self, resolve_func: &dyn Fn(Task) -> TaskProcessResult);
+    fn subscribe(&self, resolve_func: &dyn Fn(Task) -> TaskProcessResult);
 
     fn close(self) -> ManagerResult<()>;
 
-    fn contains(&self, task: &Task) -> ManagerResult<bool>;
+    fn cull_known(&self, tasks: Vec<Task>) -> ManagerResult<Vec<Task>>;
 }
 
 /// A Frontier contains upcoming tasks
 pub trait Frontier {
-    fn submit_task(&self, task: &Task) -> ManagerResult<()>;
+    fn submit(&self, task: Vec<Task>) -> ManagerResult<()>;
 
-    fn start_listening(&self, resolve_func: &dyn Fn(Task) -> TaskProcessResult);
+    fn subscribe(&self, resolve_func: &dyn Fn(Task) -> TaskProcessResult);
 
     fn close(self: Box<Self>) -> ManagerResult<()>;
 }
@@ -35,9 +35,11 @@ pub enum TaskProcessResult {
 
 /// A Collection contains every found task, which prevents work duplications
 pub trait Collection {
-    fn contains(&self, task: &Task) -> ManagerResult<bool>;
+    fn cull_known(&self, tasks: Vec<Task>) -> ManagerResult<Vec<Task>>;
 
-    fn submit_task(&self, task: &Task) -> ManagerResult<()>;
+    fn submit(&self, tasks: Vec<Task>) -> ManagerResult<()>;
+
+    fn close(self: Box<Self>) -> ManagerResult<()>;
 }
 
 /// The Downloader downloads the page S associated with the given task


### PR DESCRIPTION
Manager trait now looks like this:

```
pub trait Manager {
    fn submit(&self, tasks: Vec<Task>) -> ManagerResult<()>;

    fn subscribe(&self, resolve_func: &dyn Fn(Task) -> TaskProcessResult);

    fn close(self) -> ManagerResult<()>;

    fn cull_known(&self, tasks: Vec<Task>) -> ManagerResult<Vec<Task>>;
}
```
which enables us to pipeline commands to Redis which should be way faster. The code also got cleaner!

Depends on #97 and #100 